### PR TITLE
Update System.init to pass in SystemOptions

### DIFF
--- a/Sources/Main.hx
+++ b/Sources/Main.hx
@@ -4,7 +4,7 @@ import kha.System;
 
 class Main {
 	public static function main() {
-		System.init("Ploing", 640, 480, function () {
+		System.init({ title: "Ploing", width: 640, height: 480 }, function () {
 			new Ploing();
 		});
 	}


### PR DESCRIPTION
Did not test/compile -- edited via GitHub

I upgraded from Kha 16.1.2 (haxelib version) to the latest and got a cryptic error that `String should be kha.SystemOptions`. I looked up this sample to figure it out (it didn't help).  I thought I'd update the sample for anyone who finds this later.